### PR TITLE
Updates to yoggie view show

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,7 +104,7 @@ GEM
       thor (~> 0.14)
     font-awesome-rails (4.7.0.5)
       railties (>= 3.2, < 6.1)
-    font-awesome-sass (5.9.0)
+    font-awesome-sass (5.8.1)
       sassc (>= 1.11)
     friendly_id (5.2.5)
       activerecord (>= 4.0.0)

--- a/app/assets/stylesheets/components/_general.scss
+++ b/app/assets/stylesheets/components/_general.scss
@@ -28,3 +28,16 @@ ul {
 ul.no-style {
   list-style-type: none;
 }
+.yoggie-standard-link {
+  color: $green !important;
+  text-decoration: none;
+  opacity: 0.8;
+  letter-spacing: 0px;
+  font-weight: lighter;
+
+  &:hover {
+    color: $green;
+    opacity: 1;
+    text-decoration: underline;
+  }
+}

--- a/app/assets/stylesheets/components/_general.scss
+++ b/app/assets/stylesheets/components/_general.scss
@@ -25,3 +25,6 @@ ul {
 		color: $pink;
 	}
 }
+ul.no-style {
+  list-style-type: none;
+}

--- a/app/assets/stylesheets/pages/_smoothie.scss
+++ b/app/assets/stylesheets/pages/_smoothie.scss
@@ -101,6 +101,8 @@
 }
 .standard-yoggie-nutrition-bottom {
 	padding-top: 20px;
+  width: 100%;
+
 	h4 {
 		text-align: center;
 	}
@@ -130,18 +132,18 @@
   .yoggie-single-tabs-list {
     display: flex;
     padding: 0 15px;
-
+    justify-content: center;
 
     li {
       padding: 0 15px;
       cursor: pointer;
-      border-bottom: solid 0.5px $border;
+      border-bottom: solid 0.5px $dark-grey;
 
       &.tab--active {
         border-bottom: none;
-        border-left: solid 0.5px $border;
-        border-right: solid 0.5px $border;
-        border-top: solid 0.5px $border;
+        border-left: solid 0.5px $dark-grey;
+        border-right: solid 0.5px $dark-grey;
+        border-top: solid 0.5px $dark-grey;
         border-radius: 10px 10px 0 0;
       }
 
@@ -151,6 +153,11 @@
 
       &:hover > * {
         color: $pink !important;
+      }
+
+      &.filler-tab {
+        width: 100%;
+        border-bottom: solid 0.5px $dark-grey;
       }
     }
   }
@@ -209,33 +216,81 @@
 
         .percentage {
           font-size: 11px;
-          padding-left: 15px;
+          height: 30px;
+          width: 30px;
+          display: flex;
+          justify-content: center;
+          align-items: center;
           font-weight: 500;
+          color: white;
+          border-radius: 15px;
+          position: relative;
+          left: 15px;
+          z-index: 3;
         }
 
         .nutri {
-          padding: 0 30px;
+          width: 140px;
+          text-align: center;
+          z-index: 2;
+          background-color: white;
         }
 
         .grams {
           font-size: 11px;
-          padding-right: 15px;
           font-weight: 500;
+          height: 30px;
+          width: 30px;
+          display: flex;
+          justify-content: center;
+          align-items: center;
+          border-radius: 15px;
+          position: relative;
+          right: 15px;
+          z-index: 3;
+
+          &.half-circle {
+            z-index: 1 !important;
+          }
         }
 
         &.green-border {
-          border: 2px solid #00AB1A;
-          border-radius: 15px;
+          .percentage {
+            background-color: #00AB1A;
+          }
+          .nutri {
+            border-top: 2px solid #00AB1A;
+            border-bottom: 2px solid #00AB1A;
+          }
+          .grams {
+            border: 2px solid #00AB1A;
+          }
         }
 
         &.yellow-border {
-          border: 2px solid #DBD228;
-          border-radius: 15px;
+          .percentage {
+            background-color: #DBD228;
+          }
+          .nutri {
+            border-top: 2px solid #DBD228;
+            border-bottom: 2px solid #DBD228;
+          }
+          .grams {
+            border: 2px solid #DBD228;
+          }
         }
 
         &.orange-border {
-          border: 2px solid #FE7836;
-          border-radius: 15px;
+          .percentage {
+            background-color: #FE7836;
+          }
+          .nutri {
+            border-top: 2px solid #FE7836;
+            border-bottom: 2px solid #FE7836;
+          }
+          .grams {
+            border: 2px solid #FE7836;
+          }
         }
       }
     }

--- a/app/assets/stylesheets/pages/_smoothie.scss
+++ b/app/assets/stylesheets/pages/_smoothie.scss
@@ -119,7 +119,7 @@
 	width: 50%;
 }
 .standard-yoggie-nutrition-bottom {
-	padding-top: 20px;
+	padding-top: 30px;
   width: 100%;
 
 	h4 {
@@ -344,5 +344,15 @@
       font-size: 11px;
       padding-left: 15px;
     }
+  }
+}
+
+.ingredients-tab-content {
+  h4 {
+    margin-bottom: 0;
+    text-align: left;
+  }
+  p {
+    margin-bottom: 10px;
   }
 }

--- a/app/assets/stylesheets/pages/_smoothie.scss
+++ b/app/assets/stylesheets/pages/_smoothie.scss
@@ -95,6 +95,25 @@
 	display: flex;
 	justify-content: space-between;
 	padding: 20px 20px 0 50px;
+
+  .large-ingredients {
+    display: flex;
+
+    div {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      margin: 0 15px;
+
+      &:first-child {
+        margin-left: 0;
+      }
+
+      &:last-child {
+        margin-right: 0;
+      }
+    }
+  }
 }
 .standard-yoggie-nutrition-right {
 	width: 50%;
@@ -165,10 +184,6 @@
 
 .yoggie-single-tab-content {
   padding: 15px;
-
-  .ingredient-img-small {
-    padding: 0;
-  }
 }
 
 .yoggie-macro-tab {

--- a/app/controllers/smoothies_controller.rb
+++ b/app/controllers/smoothies_controller.rb
@@ -23,14 +23,15 @@ class SmoothiesController < ApplicationController
     @basket = BasketSmoothie.new
     @badges = @smoothie.badges
 
-    small_smooth_ingred = @smoothie.smoothie_ingredients.where(large: false)
-    @small_ingredients = small_smooth_ingred.map do |small_smoothie_ingredient|
-      small_smoothie_ingredient.ingredient
-    end
+    @small_ingredients = Ingredient.joins(:smoothie_ingredients)
+      .where(smoothie_ingredients: {smoothie: @smoothie, large: false},
+             superfood: nil).uniq
 
-    @small_ingredients = @small_ingredients.uniq
+    @large_ingredients = Ingredient.joins(:smoothie_ingredients)
+      .where(smoothie_ingredients: {smoothie: @smoothie, large: true},
+             superfood: nil).uniq
 
-    # @smoothie = Smoothie.find(params[:id])
+    @special_ingredients = Ingredient.joins(:smoothie_ingredients)
+      .where(smoothie_ingredients: {smoothie: @smoothie}).where(special: true).uniq
   end
-
 end

--- a/app/views/customers/edit.html.erb
+++ b/app/views/customers/edit.html.erb
@@ -14,7 +14,7 @@
     <%= f.input :height, label: 'Height (cm)', required: true %>
     <%= f.input :weight, label: 'Weight (kg)' , required: true%>
     <%= f.input :meals_per_day, as: :select, collection: Customer::MEALS_PER_DAY.keys, required: true  %>
-    <%= f.input :activity_level, label:'On a weekday I eat this many meals', as: :select, collection: Customer::ACTIVITY_LEVEL_MULTIPLIERS.keys, required: true %>
+    <%= f.input :activity_level, as: :select, collection: Customer::ACTIVITY_LEVEL_MULTIPLIERS.keys, required: true %>
     <%= f.input :goal, as: :select, collection: Customer::GOAL_MULTIPLIERS.keys, required: true %>
     <div class="results-button">
       <%= f.submit 'GET MY RESULTS', class: "btn-yoggie-main-green text-center" %>

--- a/app/views/smoothies/_card_tailored.html.erb
+++ b/app/views/smoothies/_card_tailored.html.erb
@@ -10,6 +10,7 @@
       <p><span>Percentage of Protein: </span><span class="your-results"><%= current_user.customer.protein %></span></p>
       <p><span>Percentage of Fat: </span><span class="your-results"><%= current_user.customer.fat %></span></p>
       <p><span>Percentage of Carbohydrate: </span><span class="your-results"><%= current_user.customer.carbs %></span></p>
+      <%= link_to "Change my numbers", edit_customer_path(current_user.customer), class: "yoggie-standard-link" %>
     </div>
     <div class="results-line"></div>
     <% end %>
@@ -21,8 +22,8 @@
     <div class="our-smoothies">
       <% smoothies.each do |smoothie| %>
       <%= link_to smoothie_path(smoothie.slug) do %>
-      <div class="standard-yoggie <%= "active" if BasketSmoothie.where(smoothie: smoothie, basket: current_user.customer.basket).count >= 1 %>">    
-      
+      <div class="standard-yoggie <%= "active" if BasketSmoothie.where(smoothie: smoothie, basket: current_user.customer.basket).count >= 1 %>">
+
       <%= cl_image_tag smoothie.image %>
         <div class="standard-yoggie-content">
             <h3><%= smoothie.name.titleize %><br></br></h3><% end %>

--- a/app/views/smoothies/index.html.erb
+++ b/app/views/smoothies/index.html.erb
@@ -8,7 +8,11 @@
 <% end %>
 <div class="our-smoothies-intro section-padding text-center">
 	<br></br>
-	<h2>Pick Your Yoggies</h2>
+  <% if current_user&.customer&.first_name&.present? %>
+    <h2><%= current_user.customer.first_name %>'s Yoggies</h2>
+  <% else %>
+	  <h2>Choose Your Yoggies</h2>
+  <% end %>
 	<br>
 </div>
 <div class="text-center">

--- a/app/views/smoothies/show.html.erb
+++ b/app/views/smoothies/show.html.erb
@@ -36,25 +36,27 @@
                 </ul>
              </div>
              <br>
-             <h4>plus:</h4> 
-             <h4>superfood:</h4> 
+             <h4>plus:</h4>
+             <h4>superfood:</h4>
         </div>
         <div class="standard-yoggie-nutrition-right">
           <h4>why it's delicious:</h4>
           <p><%= @smoothie.ingredient_description %></p>
           <br>
-          <h4>benefits to you:</h4> 
+          <h4>benefits to you:</h4>
           <br>
-          <h4>tastes great with:</h4> 
+          <h4>tastes great with:</h4>
         </div>
       </div>
 
       <div class="standard-yoggie-nutrition-bottom">
         <div class="js-tabs-container yoggie-single-tabs-container">
           <ul class="yoggie-single-tabs-list">
+            <li class="filler-tab"></li>
             <li class="js-tab tab--active" data-tab="macro"><h4>macros</h4></li>
             <li class="js-tab" data-tab="nutrition"><h4>nutrition</h4></li>
             <li class="js-tab" data-tab="ingredients"><h4>ingredients</h4></li>
+            <li class="filler-tab"></li>
           </ul>
           <div class="js-tab-content tab-content--active yoggie-single-tab-content" data-tab="macro">
             <div class="yoggie-macro-tab">
@@ -78,29 +80,35 @@
                   <li class="green-border">
                     <div class="percentage"><%= @smoothie.nutri_info.protein_percentage %>%</div>
                     <div class="nutri">Protein</div>
+                    <% if current_user.try(:customer) %>
                       <div class="grams">
-                        <% if current_user.try(:customer) %>
-                          <%= current_user.customer.calculate_tailored_stat(@smoothie, :protein_g) %>g
-                        <% end %>
+                        <%= current_user.customer.calculate_tailored_stat(@smoothie, :protein_g).round %>g
                       </div>
+                    <% else %>
+                      <div class="grams half-circle"></div>
+                    <% end %>
                   </li>
                   <li class="yellow-border">
                     <div class="percentage"><%= @smoothie.nutri_info.carbs_percentage %>%</div>
                     <div class="nutri">Carbs</div>
+                    <% if current_user.try(:customer) %>
                       <div class="grams">
-                        <% if current_user.try(:customer) %>
-                          <%= current_user.customer.calculate_tailored_stat(@smoothie, :carbs_g) %>g
-                        <% end %>
+                        <%= current_user.customer.calculate_tailored_stat(@smoothie, :carbs_g).round %>g
                       </div>
+                    <% else %>
+                      <div class="grams half-circle"></div>
+                    <% end %>
                   </li>
                   <li class="orange-border">
                     <div class="percentage"><%= @smoothie.nutri_info.fat_percentage %>%</div>
                     <div class="nutri">Fats</div>
+                    <% if current_user.try(:customer) %>
                       <div class="grams">
-                        <% if current_user.try(:customer) %>
-                          <%= current_user.customer.calculate_tailored_stat(@smoothie, :fat_g) %>g
-                        <% end %>
+                        <%= current_user.customer.calculate_tailored_stat(@smoothie, :fat_g).round %>g
                       </div>
+                    <% else %>
+                      <div class="grams half-circle"></div>
+                    <% end %>
                   </li>
                 </ul>
               </div>
@@ -126,65 +134,65 @@
                   </tr>
                   <tr class="no-bottom-border">
                     <td>Energy</td>
-                    <td><%= @smoothie.nutri_info.energy_kJ %> kJ</td>
+                    <td><%= @smoothie.nutri_info.energy_kJ.round %> kJ</td>
                     <% if current_user.try(:customer) %>
-                      <td><%= current_user.customer.calculate_tailored_stat(@smoothie, :energy_kJ) %> kJ</td>
+                      <td><%= current_user.customer.calculate_tailored_stat(@smoothie, :energy_kJ).round %> kJ</td>
                     <% end %>
                   </tr>
                   <tr>
                     <td>&nbsp;</td>
-                    <td><%= @smoothie.nutri_info.energy_kcal %> kCal</td>
+                    <td><%= @smoothie.nutri_info.energy_kcal.round %> kCal</td>
                     <% if current_user.try(:customer) %>
-                      <td><%= current_user.customer.calculate_tailored_stat(@smoothie, :energy_kcal) %> kCal</td>
+                      <td><%= current_user.customer.calculate_tailored_stat(@smoothie, :energy_kcal).round %> kCal</td>
                     <% end %>
                   </tr>
                   <tr class="no-bottom-border">
                     <td>Fat</td>
-                    <td><%= @smoothie.nutri_info.fat_g %> g</td>
+                    <td><%= @smoothie.nutri_info.fat_g.round %> g</td>
                     <% if current_user.try(:customer) %>
-                      <td><%= current_user.customer.calculate_tailored_stat(@smoothie, :fat_g) %> g</td>
+                      <td><%= current_user.customer.calculate_tailored_stat(@smoothie, :fat_g).round %> g</td>
                     <% end %>
                   </tr>
                   <tr>
                     <td class="td-small-font-indent">of which saturates</td>
-                    <td><%= @smoothie.nutri_info.fat_saturates_g %> g</td>
+                    <td><%= @smoothie.nutri_info.fat_saturates_g.round %> g</td>
                     <% if current_user.try(:customer) %>
-                      <td><%= current_user.customer.calculate_tailored_stat(@smoothie, :fat_saturates_g) %> g</td>
+                      <td><%= current_user.customer.calculate_tailored_stat(@smoothie, :fat_saturates_g).round %> g</td>
                     <% end %>
                   </tr>
                   <tr class="no-bottom-border">
                     <td>Carbohydrate</td>
-                    <td><%= @smoothie.nutri_info.carbs_g %> g</td>
+                    <td><%= @smoothie.nutri_info.carbs_g.round %> g</td>
                     <% if current_user.try(:customer) %>
-                      <td><%= current_user.customer.calculate_tailored_stat(@smoothie, :carbs_g) %> g</td>
+                      <td><%= current_user.customer.calculate_tailored_stat(@smoothie, :carbs_g).round %> g</td>
                     <% end %>
                   </tr>
                   <tr>
                     <td class="td-small-font-indent">of which sugars</td>
-                    <td><%= @smoothie.nutri_info.carbs_sugars_g %> g</td>
+                    <td><%= @smoothie.nutri_info.carbs_sugars_g.round %> g</td>
                     <% if current_user.try(:customer) %>
-                      <td><%= current_user.customer.calculate_tailored_stat(@smoothie, :carbs_sugars_g) %> g</td>
+                      <td><%= current_user.customer.calculate_tailored_stat(@smoothie, :carbs_sugars_g).round %> g</td>
                     <% end %>
                   </tr>
                   <tr>
                     <td>Fibre</td>
-                    <td><%= @smoothie.nutri_info.fibre_g %> g</td>
+                    <td><%= @smoothie.nutri_info.fibre_g.round %> g</td>
                     <% if current_user.try(:customer) %>
-                      <td><%= current_user.customer.calculate_tailored_stat(@smoothie, :fibre_g) %> g</td>
+                      <td><%= current_user.customer.calculate_tailored_stat(@smoothie, :fibre_g).round %> g</td>
                     <% end %>
                   </tr>
                   <tr>
                     <td>Protein</td>
-                    <td><%= @smoothie.nutri_info.protein_g %> g</td>
+                    <td><%= @smoothie.nutri_info.protein_g.round %> g</td>
                     <% if current_user.try(:customer) %>
-                      <td><%= current_user.customer.calculate_tailored_stat(@smoothie, :protein_g) %> g</td>
+                      <td><%= current_user.customer.calculate_tailored_stat(@smoothie, :protein_g).round %> g</td>
                     <% end %>
                   </tr>
                   <tr>
                     <td>Salt</td>
-                    <td><%= @smoothie.nutri_info.salt_g %> g</td>
+                    <td><%= @smoothie.nutri_info.salt_g.round %> g</td>
                     <% if current_user.try(:customer) %>
-                      <td><%= current_user.customer.calculate_tailored_stat(@smoothie, :salt_g) %> g</td>
+                      <td><%= current_user.customer.calculate_tailored_stat(@smoothie, :salt_g).round %> g</td>
                     <% end %>
                   </tr>
                 </tbody>
@@ -194,9 +202,9 @@
           <div class="js-tab-content yoggie-single-tab-content" data-tab="ingredients">
             <div>
               <h4>your smoothie contains...</h4>
-              <p style="width: 400px;" class="text-center">
+              <p>
                 <% @smoothie.ingredients.uniq.each do |i| %>
-                  <%= i.name.titleize %>, 
+                  <%= i.name.titleize %>,
                 <% end %>
               </p>
             </div>

--- a/app/views/smoothies/show.html.erb
+++ b/app/views/smoothies/show.html.erb
@@ -25,27 +25,58 @@
       <div class="standard-yoggie-nutrition-top">
         <div class="standard-yoggie-nutrition-topleft">
           <h4>in the mix:</h4>
-          <div>
-            <ul>
-                  <% @small_ingredients.each do |small_ingredient| %>
-                    <ul>
-                      <%= cl_image_tag(small_ingredient.image, width: 50, height: 50, crop: :fit, class: 'ingredient-img-small') %>
-                      <%= small_ingredient.name.titleize %>
-                    </ul>
+          <div class="large-ingredients">
+              <% @large_ingredients.each do |large_ingredient| %>
+                <div>
+                  <%= cl_image_tag(large_ingredient.image, width: 100, height: 100, crop: :fit, class: 'ingredient-img-small') %>
+                  <% if large_ingredient.allergen? %>
+                    <p><%= large_ingredient.name.titleize %><sup>&#10013;</sup></p>
+                  <% else %>
+                    <p><%= large_ingredient.name.titleize %></p>
                   <% end %>
-                </ul>
-             </div>
-             <br>
-             <h4>plus:</h4>
-             <h4>superfood:</h4>
+                </div>
+              <% end %>
+          </div>
+          <br>
+          <h4>plus:</h4>
+          <ul class="no-style">
+            <% @small_ingredients.each do |small_ingredient| %>
+              <li>
+                <% if small_ingredient.allergen? %>
+                  ✓ &nbsp;<%= small_ingredient.name.titleize %><sup>&#10013;</sup>
+                <% else %>
+                  ✓ &nbsp;<%= small_ingredient.name.titleize %>
+                <% end %>
+              </li>
+            <% end %>
+          </ul>
+          <br>
+          <h4>superfood:</h4>
+          <ul class="no-style">
+            <li>
+              ✓ &nbsp;<%= @smoothie.superfood.titleize %>
+            </li>
+          </ul>
         </div>
         <div class="standard-yoggie-nutrition-right">
           <h4>why it's delicious:</h4>
           <p><%= @smoothie.ingredient_description %></p>
           <br>
           <h4>benefits to you:</h4>
+          <ul>
+            <% if @smoothie.benefits_one.present? %>
+              <li><%= @smoothie.benefits_one %></li>
+            <% end %>
+            <% if @smoothie.benefits_two.present? %>
+              <li><%= @smoothie.benefits_two %></li>
+            <% end %>
+            <% if @smoothie.benefits_three.present? %>
+              <li><%= @smoothie.benefits_three %></li>
+            <% end %>
+          </ul>
           <br>
           <h4>tastes great with:</h4>
+          <p><%= @smoothie.great_with %></p>
         </div>
       </div>
 

--- a/app/views/smoothies/show.html.erb
+++ b/app/views/smoothies/show.html.erb
@@ -231,13 +231,38 @@
             </div>
           </div>
           <div class="js-tab-content yoggie-single-tab-content" data-tab="ingredients">
-            <div>
-              <h4>your smoothie contains...</h4>
-              <p>
-                <% @smoothie.ingredients.uniq.each do |i| %>
-                  <%= i.name.titleize %>,
-                <% end %>
-              </p>
+            <div class="ingredients-tab-content">
+              <div class="row">
+                <div class="col-xs-6">
+                  <h4>Smoothie contains</h4>
+                  <p>
+                    <%= @smoothie.ingredients.uniq.map{|i| i.name.titleize}.join(", ") %>
+                  </p>
+                  <br>
+                  <h4>Ingredients contain</h4>
+                  <% @special_ingredients.each do |special_ingredient| %>
+                    <p>
+                      <strong>
+                        <%= special_ingredient.name.titleize %>
+                      </strong>
+                    </p>
+                    <p style="word-wrap: break-word;">
+                      <%= special_ingredient.contents %>
+                    </p>
+                  <% end %>
+                </div>
+                <div class="col-xs-6">
+                  <h4>Allergens</h4>
+                  <p>
+                    <strong>
+                      For allergens see ingredients with symbol &#10013; and/or in bold text
+                    </strong>
+                  </p>
+                  <p>
+                    In addition to the above, due to the environment within our packaging facility, our packs may contain low levels of the following allergens: Cereals containing gluten; Crustaceans; Eggs; Fish; Peanuts; Soya; Milk; Nuts: almonds, hazelnuts, walnuts, cashews, pecan nuts, brazil nuts, pistachio nuts, macadamia nuts; Celery; Sesame; Sulphur dioxide and Sulphites; Lupin; Molluscs; Mustard.
+                  </p>
+                </div>
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
"Choose your yoggie" pages: 
- ‘firstname’s Yoggies’ instead of ‘Choose your Yoggies’
- ‘Change my numbers’ link to the customisation questions

"View yoggie" pages: 
- make tabs clearer
- Macro tab diagram with html and css
- Nutrition tab data rounded to a whole number 
- large ingredients with image go in "in the mix"small ingredients go in "plus"
- cross next to allergens
- add "benefits to you"
- add "tastes great with"
- add "superfoods"
- special ingredients and description in ingredients tab